### PR TITLE
Refactor classic_mode() to be a class instead of a function

### DIFF
--- a/game.py
+++ b/game.py
@@ -11,91 +11,114 @@ from utility import Utility
 from random import randint, choice
 from constants import *
 
-def classic_mode():
-    """
-    Classic mode of the game.
-    """
-    bext.clear()
-    Map.print_map("green", REFRESH_RATE)
-    unassigned_countries = []
+class ClassicMode:
+    def __init__(self):
+        self.unassigned_countries = []
+        self.all_countries = []
+        self.player_country = ""
+        self.allies = []
+        self.enemies = []
+        self.original_allies = []
+        self.original_enemies = []
 
-    for country in countries:
-        countries[country]['status'] = True
-        unassigned_countries.append(country)
+    def run(self):
+        bext.clear()
+        Map.print_map("green", REFRESH_RATE)
+        self.unassigned_countries = []
 
-    all_countries = unassigned_countries.copy()
-
-    bext.goto(0, 48)
-    player_country = pyinputplus.inputMenu(
-        unassigned_countries, "CHOOSE A COUNTRY:\n", numbered=True)
-
-    unassigned_countries.remove(player_country)
-
-    allies = []
-    enemies = []
-
-    ally_limit = randint(2,5)
-    enemies_limit = len(all_countries) - ally_limit
-
-    for country in unassigned_countries:
-        if len(allies) < ally_limit:
-            allies.append(country)
-        else:
-            enemies.append(country)
-
-    original_allies = allies.copy()
-    original_enemies = enemies.copy()
-
-    Draw.player_list(allies, enemies, player_country)
-
-    def draw_bases():
         for country in countries:
-            if country == player_country:
+            countries[country]['status'] = True
+            self.unassigned_countries.append(country)
+
+        self.all_countries = self.unassigned_countries.copy()
+
+        bext.goto(0, 48)
+        self.player_country = pyinputplus.inputMenu(
+            self.unassigned_countries, "CHOOSE A COUNTRY:\n", numbered=True)
+
+        self.unassigned_countries.remove(self.player_country)
+
+        self.allies = []
+        self.enemies = []
+
+        ally_limit = randint(2, 5)
+        enemies_limit = len(self.all_countries) - ally_limit
+
+        for country in self.unassigned_countries:
+            if len(self.allies) < ally_limit:
+                self.allies.append(country)
+            else:
+                self.enemies.append(country)
+
+        self.original_allies = self.allies.copy()
+        self.original_enemies = self.enemies.copy()
+
+        Draw.player_list(self.allies, self.enemies, self.player_country)
+
+        turn = 1
+        while len(self.enemies) != 0 and (countries[self.player_country]['status'] == True):
+            self.draw_bases()
+            Draw.player_list(self.original_allies, self.original_enemies, self.player_country)
+            if turn % 2 == 0 and countries[self.player_country]['status'] == True:
+                self.automove()
+            else:
+                self.playermove()
+            turn += 1
+            Draw.player_list(self.original_allies, self.original_enemies, self.player_country)
+
+        if countries[self.player_country]['status'] == False:
+            self.base_message(f'YOU LOST IN {turn} TURNS, RESTARTING IN 10s', self.player_country)
+        else:
+            self.base_message(f'YOU WON IN {turn} TURNS, RESTARTING IN 10s', self.player_country)
+
+    def draw_bases(self):
+        for country in countries:
+            if country == self.player_country:
                 bext.fg('yellow')
-            elif country in enemies:
+            elif country in self.enemies:
                 bext.fg('red')
-            elif country in allies:
+            elif country in self.allies:
                 bext.fg('white')
             elif countries[country]['status'] == False:
                 bext.fg('blue')
             bext.goto(countries[country]['location'][0],
-                    countries[country]['location'][1])
+                      countries[country]['location'][1])
             print('@')
 
-    def playermove():
+    def playermove(self):
         """
         Ask the player what countries it should target.
         """
         Draw.clear_console()
 
-        if len(enemies) > 1:
-            target = pyinputplus.inputMenu(enemies, "CHOSE A COUNTRY TO TARGET:\n", lettered=True)
+        if len(self.enemies) > 1:
+            target = pyinputplus.inputMenu(self.enemies, "CHOSE A COUNTRY TO TARGET:\n", lettered=True)
         else:
-            target = enemies[0]            
+            target = self.enemies[0]
 
-        start_coords = (countries[player_country]['location'][0], 
-                       countries[player_country]['location'][1])
+        start_coords = (countries[self.player_country]['location'][0],
+                        countries[self.player_country]['location'][1])
         target_coords = (countries[target]['location'][0],
-                        countries[target]['location'][1])
-    
+                         countries[target]['location'][1])
+
         Missiles.ICBM_bresenham(start_coords, target_coords)
         Draw.draw_fallout(target_coords, 2, REFRESH_RATE, "purple", "*")
 
-        enemies.remove(target)
+        self.enemies.remove(target)
         countries[target]['status'] = False
 
-    def automove():
+    def automove(self):
         """
         Randomly selects a country to fire at one of its enemies.
         """
-        remaining_countries = enemies + allies 
+        remaining_countries = self.enemies + self.allies
         start = choice(remaining_countries)
         remaining_countries.remove(start)
-        if start in enemies:
-            possible_targets = allies
-            possible_targets.append(player_country)
-        elif start in allies:
-            possible_targets = enemies
+        if start in self.enemies:
+            possible_targets = self.allies
+            possible_targets.append(self.player_country)
+        elif start in self.allies:
+            possible_targets = self.enemies
         target = choice(possible_targets)
 
         start_x = countries[start]['location'][0]
@@ -103,21 +126,20 @@ def classic_mode():
         strike_x = countries[target]['location'][0]
         strike_y = countries[target]['location'][1]
 
-
-        if target in enemies:
-            enemies.remove(target)
+        if target in self.enemies:
+            self.enemies.remove(target)
             countries[target]['status'] = False
-        elif target in allies:
-            allies.remove(target)
+        elif target in self.allies:
+            self.allies.remove(target)
             countries[target]['status'] = False
-        elif target == player_country:
+        elif target == self.player_country:
             countries[target]['status'] = False
 
         Missiles.ICBM_bresenham((start_x, start_y), (strike_x, strike_y))
         Draw.draw_fallout((strike_x, strike_y), 2, REFRESH_RATE, "purple", "*")
-        draw_bases()
+        self.draw_bases()
 
-    def base_message(text: str, country: str):
+    def base_message(self, text: str, country: str):
         """
         Print a message at a specific country's silo location.
 
@@ -126,54 +148,35 @@ def classic_mode():
             country (str): The country where the message will be printed.
         """
         bext.goto(countries[country]['location'][0],
-                    countries[country]['location'][1])
+                  countries[country]['location'][1])
         bext.bg('RED')
         bext.fg('BLACK')
         print(text)
         bext.bg('reset')
         bext.fg('reset')
         time.sleep(10)
-        
-
-
-
-    turn = 1
-    while len(enemies) != 0 and (countries[player_country]['status'] == True):
-        draw_bases()
-        Draw.player_list(original_allies, original_enemies, player_country)
-        if turn % 2 == 0 and countries[player_country]['status'] == True:
-            automove()
-        else:
-            playermove()
-        turn += 1
-        Draw.player_list(original_allies, original_enemies, player_country)
-
-    if countries[player_country]['status'] == False:
-        base_message(f'YOU LOST IN {turn} TURNS, RESTARTING IN 10s', player_country)
-    else:
-        base_message(f'YOU WON IN {turn} TURNS, RESTARTING IN 10s', player_country)
 
 
 class Submarine:
-	"""
-	Class representing a submarine.
-	"""
-	allies = []
-	enemies = []
+    """
+    Class representing a submarine.
+    """
+    allies = []
+    enemies = []
 
-	def __init__(self, xy: tuple, country: str):
-		"""
-			Initialize a submarine.
+    def __init__(self, xy: tuple, country: str):
+        """
+            Initialize a submarine.
 
-			Args:
-				xy (tuple): The coordinates of the submarine.
-				country (str): The country to which the submarine belongs.
-			"""
-		self.country = country
-		self.coords = xy
-		self.status = True
-		self.destroyed = False
-		self.allies.append(self.country)
+            Args:
+                xy (tuple): The coordinates of the submarine.
+                country (str): The country to which the submarine belongs.
+            """
+        self.country = country
+        self.coords = xy
+        self.status = True
+        self.destroyed = False
+        self.allies.append(self.country)
 
 
 class SubsAndSilos():
@@ -188,7 +191,7 @@ class SubsAndSilos():
         bext.clear()
         Map.print_map("yellow", SPEED=REFRESH_RATE, ocean=True)
         Draw.clear_console()
-        
+
     def ask_for_ocean_coords():
         """
         Ask the user for the coordinates of the ocean.
@@ -227,16 +230,16 @@ class SubsAndSilos():
             if Missiles.get_distance(player_sub[0], player_sub[1], xy[0], xy[1]) < (radius * 1.2):
                 coords = Draw.draw_line(player_sub[0], player_sub[1], xy[0], xy[1], COLOUR="BLUE")
                 time.sleep(0.0002)
-                visible_coords.extend(coords) 
+                visible_coords.extend(coords)
             else:
                 if player_sub[0] < (152 / 2):
                     subx, suby = player_sub[0] + 154, player_sub[1]
-                    visible_coords.extend( Draw.draw_line(subx - 154, suby, 1, xy[1], COLOUR="BLUE"))
-                    visible_coords.extend( Draw.draw_line(subx, suby, xy[0], xy[1], COLOUR="BLUE"))
+                    visible_coords.extend(Draw.draw_line(subx - 154, suby, 1, xy[1], COLOUR="BLUE"))
+                    visible_coords.extend(Draw.draw_line(subx, suby, xy[0], xy[1], COLOUR="BLUE"))
                 else:
                     subx, suby = player_sub[0] - 154, player_sub[1]
-                    visible_coords.extend( Draw.draw_line(player_sub[0], suby, 153, xy[1], COLOUR="BLUE"))
-                    visible_coords.extend( Draw.draw_line(subx, suby, xy[0], xy[1], COLOUR="BLUE"))
+                    visible_coords.extend(Draw.draw_line(player_sub[0], suby, 153, xy[1], COLOUR="BLUE"))
+                    visible_coords.extend(Draw.draw_line(subx, suby, xy[0], xy[1], COLOUR="BLUE"))
 
                 time.sleep(0.006)
         return Utility.remove_duplicates(visible_coords)
@@ -252,7 +255,7 @@ class SubsAndSilos():
             list: List of coordinates affected by the attack.
         """
         circle = Draw.draw_circle(countries[player_country]['subs'][0][0], countries[player_country]['subs'][0][1], RADIUS=20, COLOUR="RED", erase_map_tiles=True)
-        coords_inside_circle = Map.get_coordinates_inside_circle((countries[player_country]['subs'][0][0], countries[player_country]['subs'][0][1]), circle)    
+        coords_inside_circle = Map.get_coordinates_inside_circle((countries[player_country]['subs'][0][0], countries[player_country]['subs'][0][1]), circle)
         missile_coords_valid = False
         while not missile_coords_valid:
             Draw.clear_console()
@@ -264,7 +267,7 @@ class SubsAndSilos():
                 Draw.console("ERR: TARGET NOT IN PROXIMITY!")
                 time.sleep(2)
         return Missiles.ICBM_bresenham(countries[player_country]['subs'][0], target_coords)
-                
+
     def action_move(subxy: tuple, direction: str, distance: int):
         """
         Move the submarine in the specified direction.
@@ -306,7 +309,7 @@ class SubsAndSilos():
         for country_name, country_data in countries.items():
             if country_name in seeking_countries:
                 sub_coords.extend(country_data["subs"])
-        
+
         found_subs = []
         for sub_coords in sub_coords:
             if sub_coords in search_coords:
@@ -338,7 +341,7 @@ class SubsAndSilos():
         allies = []
         enemies = []
 
-        ally_limit = randint(2,5)
+        ally_limit = randint(2, 5)
         enemies_limit = len(all_countries) - ally_limit
 
         for country in unassigned_countries:
@@ -353,20 +356,19 @@ class SubsAndSilos():
         Draw.player_list(allies, enemies, player_country)
 
         Map.print_silos(player_country, enemies, allies)
-        
+
         Draw.clear_console()
         player_sub_x, player_sub_y = SubsAndSilos.ask_for_ocean_coords()
         countries[player_country]['subs'].append((player_sub_x, player_sub_y))
-        
+
         ocean_coords = Map.get_ocean_tiles()
         for country_name, country_data in countries.items():
             if country_name in enemies or country_name in allies and not country_name == player_country:
                 country_data['subs'].append(choice(ocean_coords))
-        
+
         Map.print_subs(player_country, allies=allies)
 
         return player_country, enemies, allies, original_allies, original_enemies
-            
 
     def player_move(player_country, enemies, allies, original_allies, original_enemies):
         """
@@ -392,7 +394,7 @@ class SubsAndSilos():
             Draw.draw_circle(player_sub_x, player_sub_y, RADIUS=distance_max, COLOUR="GREEN")
             Draw.clear_console()
             move_direction = pyinputplus.inputMenu(["N", "S", "E", "W"], "What direction would you like to move?\n", lettered=True)
-            move_distance = pyinputplus.inputInt("How many tiles would you like to move?\n", min=1, max=distance_max-1)
+            move_distance = pyinputplus.inputInt("How many tiles would you like to move?\n", min=1, max=distance_max - 1)
             new_sub_coords = SubsAndSilos.action_move((player_sub_x, player_sub_y), move_direction, move_distance)
             if new_sub_coords:
                 countries[player_country]['subs'][0] = SubsAndSilos.action_move(countries[player_country]['subs'][0], move_direction, move_distance)
@@ -416,7 +418,7 @@ class SubsAndSilos():
             if visible_subs:
                 Draw.console(f"Detected enemies at: {visible_subs}")
                 time.sleep(5)
-            
+
         return player_country, enemies, allies, original_allies, original_enemies
 
     def enemy_move(player_country, enemies, allies, original_allies, original_enemies):
@@ -435,14 +437,14 @@ class SubsAndSilos():
         for country in enemies:
             move_valid = False
             while not move_valid:
-                move_distance = randint(5,10)
+                move_distance = randint(5, 10)
                 possible_moves = Draw.draw_circle(countries[country]['subs'][0][0], countries[country]['subs'][0][1], RADIUS=move_distance, visible=False)
                 new_sub_coords = choice(possible_moves)
                 travel_line = Draw.get_line(countries[country]["subs"][0], new_sub_coords)
                 if new_sub_coords and Map.check_for_obstruction(travel_line):
                     move_valid = True
             countries[country]["subs"][0] = new_sub_coords
-            
+
             Draw.console(f"{country} SUBMARINE WARHEAD CARRIER MOVED")
             time.sleep(0.8)
             for tile in travel_line:
@@ -452,7 +454,6 @@ class SubsAndSilos():
                     Draw.draw_char(tile[0], tile[1], ">", COLOUR="GREEN")
                 time.sleep(0.1)
             time.sleep(3)
-
 
 
 def submarinesandsilos():
@@ -476,7 +477,8 @@ def main():
 
     while True:
         Draw.clear_console()
-        classic_mode()
+        classic_mode = ClassicMode()
+        classic_mode.run()
         sys.exit()
 
 


### PR DESCRIPTION
Refactor `classic_mode()` function into a `ClassicMode` class.

* Create a `ClassicMode` class in `game.py` to encapsulate the `classic_mode()` function.
* Move nested functions `draw_bases()`, `playermove()`, `automove()`, and `base_message()` to methods of the `ClassicMode` class.
* Update the `main()` function to create an instance of the `ClassicMode` class and call its `run()` method.
* Adjust the logic within the `ClassicMode` class to use instance variables instead of local variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/illegalbyte/WOPR/pull/9?shareId=399f9383-6c5d-4b67-80e0-8c923d93c7e3).